### PR TITLE
Add execute permission and shebang line

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import json
 import time
 import requests


### PR DESCRIPTION
This pull request makes main.py executable in unix environments by adding shebang line on top of file (so system knows which interpreter to use, in this case it's python3) and adding the x or execute permission (`chmod +x main.py`) so that the script can be started by just typing command `./main.py`,